### PR TITLE
fixing detailed view for eratic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "eve-reactions-calculator",
-	"version": "2.8.0",
+	"version": "2.8.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "eve-reactions-calculator",
-			"version": "2.8.0",
+			"version": "2.8.1",
 			"dependencies": {
 				"better-sqlite3": "^12.5.0",
 				"csv-parse": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eve-reactions-calculator",
-	"version": "2.8.0",
+	"version": "2.8.1",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev",

--- a/src/routes/composite/+page.svelte
+++ b/src/routes/composite/+page.svelte
@@ -81,7 +81,7 @@
 	</div>
 
 	<div class="row mt-4">
-		<div class="card w-100 p-0">
+		<div class="card w-100 p-0" id="simple-reactions-card">
 			<div class="card-header bg-info text-white fw-bold text-center w-100">Simple Reactions</div>
 			<table width="100%" id="stab" class="table table-bordered text-center">
 				<thead>
@@ -115,7 +115,7 @@
 			</table>
 		</div>
 
-		<div class="card w-100 mt-4 p-0">
+		<div class="card w-100 mt-4 p-0" id="complex-reactions-card">
 			<div class="card-header bg-info text-white fw-bold text-center w-100">Complex Reactions</div>
 			<table width="100%" id="stab" class="table table-bordered text-center">
 				<thead>
@@ -149,7 +149,7 @@
 			</table>
 		</div>
 
-		<div class="card w-100 mt-4 p-0">
+		<div class="card w-100 mt-4 p-0" id="chain-reactions-card">
 			<div class="card-header bg-info text-white fw-bold text-center w-100">
 				Complex Chain Reactions
 			</div>
@@ -185,7 +185,7 @@
 			</table>
 		</div>
 
-		<div class="card w-100 mt-4 p-0">
+		<div class="card w-100 mt-4 p-0" id="unrefined-reactions-card">
 			<div class="card-header bg-info text-white fw-bold text-center w-100">
 				Unrefined Reactions (not reprocessed)
 			</div>
@@ -221,7 +221,7 @@
 			</table>
 		</div>
 
-		<div class="card w-100 mt-4 p-0">
+		<div class="card w-100 mt-4 p-0" id="refined-reactions-card">
 			<div class="card-header bg-info text-white fw-bold text-center w-100">
 				Unrefined Reactions (55% Efficiency)
 			</div>
@@ -257,9 +257,9 @@
 			</table>
 		</div>
 
-		<div class="card w-100 mt-4 p-0">
+		<div class="card w-100 mt-4 p-0" id="eratic-reactions-card">
 			<div class="card-header bg-info text-white fw-bold text-center w-100">
-				Unrefined Mineral Reactions (eratic)
+				Unrefined Mineral Reactions (no reprocessing)
 			</div>
 			<table width="100%" id="stab" class="table table-bordered text-center">
 				<thead>
@@ -293,9 +293,9 @@
 			</table>
 		</div>
 
-		<div class="card w-100 mt-4 p-0">
+		<div class="card w-100 mt-4 p-0" id="eratic-repro-card">
 			<div class="card-header bg-info text-white fw-bold text-center w-100">
-				Unrefined Mineral Reactions (eratic MAX Refine)
+				Unrefined Mineral Reactions (MAX Refine 90.63%)
 			</div>
 			<table width="100%" id="stab" class="table table-bordered text-center">
 				<thead>

--- a/src/routes/composite/[type]/[id=integer]/+page.server.js
+++ b/src/routes/composite/[type]/[id=integer]/+page.server.js
@@ -164,7 +164,8 @@ export const load = async ({ cookies, platform, params }) => {
 				blueprints,
 				parseInt(params.id),
 				0,
-				true
+				true,
+				60
 			);
 			break;
 
@@ -188,7 +189,7 @@ export const load = async ({ cookies, platform, params }) => {
 				parseInt(params.id),
 				0,
 				true,
-				360,
+				60,
 				0.9063
 			);
 			break;


### PR DESCRIPTION
This pull request introduces minor updates to the `eve-reactions-calculator` project, primarily focused on improving the maintainability and clarity of the composite reactions page. The most significant changes involve assigning unique IDs to reaction cards for easier referencing and updating parameters in server-side logic to ensure consistency.

**UI improvements:**

* Assigned unique IDs to each reaction card in `src/routes/composite/+page.svelte` for better DOM targeting and future maintainability. Cards affected include simple, complex, chain, unrefined, refined, and eratic reactions. [[1]](diffhunk://#diff-99c24c7a8bc1d665c86b8b0770b7459914bcbd4d9d38841a8de5590a0434e39dL84-R84) [[2]](diffhunk://#diff-99c24c7a8bc1d665c86b8b0770b7459914bcbd4d9d38841a8de5590a0434e39dL118-R118) [[3]](diffhunk://#diff-99c24c7a8bc1d665c86b8b0770b7459914bcbd4d9d38841a8de5590a0434e39dL152-R152) [[4]](diffhunk://#diff-99c24c7a8bc1d665c86b8b0770b7459914bcbd4d9d38841a8de5590a0434e39dL188-R188) [[5]](diffhunk://#diff-99c24c7a8bc1d665c86b8b0770b7459914bcbd4d9d38841a8de5590a0434e39dL224-R224) [[6]](diffhunk://#diff-99c24c7a8bc1d665c86b8b0770b7459914bcbd4d9d38841a8de5590a0434e39dL260-R262) [[7]](diffhunk://#diff-99c24c7a8bc1d665c86b8b0770b7459914bcbd4d9d38841a8de5590a0434e39dL296-R298)
* Updated card headers for eratic mineral reactions to clarify reprocessing status and efficiency percentages. [[1]](diffhunk://#diff-99c24c7a8bc1d665c86b8b0770b7459914bcbd4d9d38841a8de5590a0434e39dL260-R262) [[2]](diffhunk://#diff-99c24c7a8bc1d665c86b8b0770b7459914bcbd4d9d38841a8de5590a0434e39dL296-R298)

**Backend logic updates:**

* Changed the reprocessing efficiency parameter from `360` to `60` in `src/routes/composite/[type]/[id=integer]/+page.server.js` to standardize calculation logic. ([src/routes/composite/[type]/[id=integer]/+page.server.jsL191-R192](diffhunk://#diff-86019b10302245224bd21a0650a09c17c736f87ca3618dd70f6f049d8ada912fL191-R192))
* Added an explicit `60` parameter to blueprint calculation calls for consistency. ([src/routes/composite/[type]/[id=integer]/+page.server.jsL167-R168](diffhunk://#diff-86019b10302245224bd21a0650a09c17c736f87ca3618dd70f6f049d8ada912fL167-R168))

**Meta changes:**

* Bumped the project version from `2.8.0` to `2.8.1` in `package.json` to reflect these updates.